### PR TITLE
doc: add sudo to all ipmctl command lines exapmles

### DIFF
--- a/ipmctl-user-guide/debug/delete-device-platform-configuration-data.md
+++ b/ipmctl-user-guide/debug/delete-device-platform-configuration-data.md
@@ -5,7 +5,7 @@ When `Config` is specified, the `Current`, `Input Data Size`, `Output Data Size`
 > Warning: This command may result in data loss. Data should be backed up to other storage before executing this command.
 
 ```text
-$ ipmctl delete [OPTIONS] -dimm (DimmIds) -pcd (Config)
+ipmctl delete [OPTIONS] -dimm (DimmIds) -pcd (Config)
 ```
 
 ### **Targets**

--- a/ipmctl-user-guide/debug/dump-debug-log.md
+++ b/ipmctl-user-guide/debug/dump-debug-log.md
@@ -20,7 +20,7 @@ ipmctl dump [OPTIONS] -destination (file_prefix) [-dict (file)] -debug -dimm (Di
 Dump and decode the debug log from persistent memory modules 0x0001 and 0x0011 using the dictionary file.
 
 ```text
-$ ipmctl dump -destination file_prefix -dict nlog_dict.txt -debug -dimm 0x0001,0x0011
+$ sudo ipmctl dump -destination file_prefix -dict nlog_dict.txt -debug -dimm 0x0001,0x0011
 ```
 
 ### **Sample Output**

--- a/ipmctl-user-guide/debug/inject-error.md
+++ b/ipmctl-user-guide/debug/inject-error.md
@@ -50,48 +50,48 @@ This command supports setting or clearing one type of error at a time
 Set the media temperature on all manageable modules to 100 degrees Celsius.
 
 ```text
-$ ipmctl set -dimm Temperature=100
+$ sudo ipmctl set -dimm Temperature=100
 ```
 
 Clear the injected media temperature on all manageable modules
 
 ```text
-$ ipmctl set -dimm Clear=1 Temperature=1
+$ sudo ipmctl set -dimm Clear=1 Temperature=1
 ```
 
 Poison address 0x10000100 on module 1234
 
 ```text
-$ ipmctl set -dimm 1234 Poison=0x10000200
+$ sudo ipmctl set -dimm 1234 Poison=0x10000200
 ```
 
 Clear the injected poison of address 0x10000200 on module 1234.
 
 ```text
-$ ipmctl set -dimm 1234 Poison=0x10000200 Clear=1
+$ sudo ipmctl set -dimm 1234 Poison=0x10000200 Clear=1
 ```
 
 Trigger an artificial package sparing on all manageable modules.
 
 ```text
-$ ipmctl set -dimm PackageSparing=1
+$ sudo ipmctl set -dimm PackageSparing=1
 ```
 
 Set the life remaining percentage on all manageable modules to 10%.
 
 ```text
-$ ipmctl set -dimm PercentageRemaining=10
+$ sudo ipmctl set -dimm PercentageRemaining=10
 ```
 
 Clear the injected remaining life percentage on all manageable modules. The value of PercentageRemaining is irrelevant.
 
 ```text
-$ ipmctl set -dimm PercentageRemaining=10 Clear=1
+$ sudo ipmctl set -dimm PercentageRemaining=10 Clear=1
 ```
 
 Trigger an artificial ADR failure on all manageable modules, which will result in a dirty shutdown on each module on the next reboot.
 
 ```text
-$ ipmctl set -dimm DirtyShutdown=1
+$ sudo ipmctl set -dimm DirtyShutdown=1
 ```
 

--- a/ipmctl-user-guide/debug/run-diagnostic.md
+++ b/ipmctl-user-guide/debug/run-diagnostic.md
@@ -21,13 +21,13 @@ ipmctl start [OPTIONS] -diagnostic (Quick|Config|Security|FW) -dimm(DIMMIDs)
 Run all diagnostics
 
 ```text
-$ ipmctl start -diagnostic
+$ sudo ipmctl start -diagnostic
 ```
 
 Run the quick check diagnostic on module 0x0001
 
 ```text
-$ ipmctl start -diagnostic Quick -dimm 0x0001
+$ sudo ipmctl start -diagnostic Quick -dimm 0x0001
 ```
 
 ### **Return Data**

--- a/ipmctl-user-guide/debug/show-acpi-tables.md
+++ b/ipmctl-user-guide/debug/show-acpi-tables.md
@@ -3,7 +3,7 @@
 Shows the system ACPI tables related to persistent memory modules.
 
 ```text
-$ ipmctl show [OPTIONS] -system (NFIT|PCAT|PMTT)
+ipmctl show [OPTIONS] -system (NFIT|PCAT|PMTT)
 ```
 
 ### **Targets**
@@ -20,7 +20,7 @@ $ ipmctl show [OPTIONS] -system (NFIT|PCAT|PMTT)
 Show the ACPI NFIT
 
 ```text
-$ ipmctl show -system NFIT
+$ sudo ipmctl show -system NFIT
 ```
 
 ### **Return Data** 

--- a/ipmctl-user-guide/debug/show-device-platform-configuration-data.md
+++ b/ipmctl-user-guide/debug/show-device-platform-configuration-data.md
@@ -3,7 +3,7 @@
 Shows the platform configuration data for one or more persistent memory modules.
 
 ```text
-$ ipmctl show [OPTIONS] -dimm (DimmIds) -pcd (Config|LSA)
+ipmctl show [OPTIONS] -dimm (DimmIds) -pcd (Config|LSA)
 ```
 
 ### **Targets**
@@ -18,7 +18,7 @@ $ ipmctl show [OPTIONS] -dimm (DimmIds) -pcd (Config|LSA)
 Show the configuration information from the platform configuration data for all manageable modules
 
 ```text
-$ ipmctl show -dimm -pcd
+$ sudo ipmctl show -dimm -pcd
 ```
 
 Show the configuration information from the platform configuration data for module 0x0001

--- a/ipmctl-user-guide/debug/show-error-log.md
+++ b/ipmctl-user-guide/debug/show-error-log.md
@@ -3,7 +3,7 @@
 Shows thermal or media errors on the specified persistent memory modules.
 
 ```text
-$ ipmctl show [OPTIONS] -error (Thermal|Media) [TARGETS] [PROPERTIES]
+ipmctl show [OPTIONS] -error (Thermal|Media) [TARGETS] [PROPERTIES]
 ```
 
 ### **Targets**
@@ -23,13 +23,13 @@ $ ipmctl show [OPTIONS] -error (Thermal|Media) [TARGETS] [PROPERTIES]
 Show all high thermal error log entries
 
 ```text
-$ ipmctl show -error Thermal Level=High
+$ sudo ipmctl show -error Thermal Level=High
 ```
 
 Show all low media error log entries
 
 ```text
-$ ipmctl show -error Thermal Level=Low
+$ sudo ipmctl show -error Thermal Level=Low
 ```
 
 ### **Sample Output**

--- a/ipmctl-user-guide/instrumentation/change-sensor-settings.md
+++ b/ipmctl-user-guide/instrumentation/change-sensor-settings.md
@@ -3,7 +3,7 @@
 Changes the non-critical threshold or enabled state for one or more persistent memory module sensors. Use the command [Show Sensor](show-sensor.md) to view the current settings.
 
 ```text
-$ ipmctl set [OPTIONS] -sensor (SENSORS) [TARGETS] NonCriticalThreshold=(temperature) EnabledState=(0|1)
+ipmctl set [OPTIONS] -sensor (SENSORS) [TARGETS] NonCriticalThreshold=(temperature) EnabledState=(0|1)
 ```
 
 ### **Sensors**

--- a/ipmctl-user-guide/instrumentation/show-device-performance.md
+++ b/ipmctl-user-guide/instrumentation/show-device-performance.md
@@ -30,12 +30,12 @@ The default is to display all performance metrics.
 Show all performance metrics for all modules in the server
 
 ```text
-$ ipmctl show -dimm -performance
+$ sudo ipmctl show -dimm -performance
 ```
 
 Show the number of 64 byte reads since last AC cycle for all modules in the server
 
 ```text
-$ ipmctl show -dimm -performance MediaReads
+$ sudo ipmctl show -dimm -performance MediaReads
 ```
 

--- a/ipmctl-user-guide/instrumentation/show-sensor.md
+++ b/ipmctl-user-guide/instrumentation/show-sensor.md
@@ -3,7 +3,7 @@
 Shows health statistics for one or more persistent memory modules.
 
 ```text
-$ ipmctl show [OPTOINS] -sensor [SENSORS] [TARGETS]
+ipmctl show [OPTOINS] -sensor [SENSORS] [TARGETS]
 ```
 
 ### **Sensors**
@@ -28,13 +28,13 @@ $ ipmctl show [OPTOINS] -sensor [SENSORS] [TARGETS]
 Get all sensor information for all modules
 
 ```text
-$ ipmctl show -sensor
+$ sudo ipmctl show -sensor
 ```
 
 Show the media temperature sensor for the specified module
 
 ```text
-$ ipmctl show -sensor MediaTemperature -dimm 0x0011
+$ sudo ipmctl show -sensor MediaTemperature -dimm 0x0011
 ```
 
 ### **Return Data**

--- a/ipmctl-user-guide/module-discovery/README.md
+++ b/ipmctl-user-guide/module-discovery/README.md
@@ -5,9 +5,9 @@ Persistent memory modules are uniquely referenced by one of two IDs: `DimmHandle
 For example, each of the following are equivalent:
 
 ```text
-    $ ipmctl show -d DimmHandle,DimmUID -dimm 8089-a2-1748-00000001
-    $ ipmctl show -d DimmHandle,DimmUID -dimm 0x0001
-    $ ipmctl show -d DimmHandle,DimmUID -dimm 1
+$ sudo ipmctl show -d DimmHandle,DimmUID -dimm 8089-a2-1748-00000001
+$ sudo ipmctl show -d DimmHandle,DimmUID -dimm 0x0001
+$ sudo ipmctl show -d DimmHandle,DimmUID -dimm 1
 ```
 
 For simplicity, this document will primarily use `DimmUID`.
@@ -15,14 +15,14 @@ For simplicity, this document will primarily use `DimmUID`.
 The `-dimm` option accepts a single DimmUID or a comma separated list of DimmUIDs to filter the results. For example, the following `ipmctl show` command displays the `DimmHandle` and `DimmUID` properties for two modules with IDs of `0x0001` and `0x1001`:
 
 ```text
-    $ ipmctl show -d DimmHandle,DimmUID -dimm 0x0001,0x1001
+$ sudo ipmctl show -d DimmHandle,DimmUID -dimm 0x0001,0x1001
 
-    ---DimmID=0x0001---
-     DimmHandle=0x0001
-     DimmUID=8089-a2-1748-00000001
-    ---DimmID=0x1001---
-     DimmHandle=0x1001
-     DimmUID=8089-a2-1748-00000002
+---DimmID=0x0001---
+ DimmHandle=0x0001
+ DimmUID=8089-a2-1748-00000001
+---DimmID=0x1001---
+ DimmHandle=0x1001
+ DimmUID=8089-a2-1748-00000002
 ```
 
 #### DimmHandle

--- a/ipmctl-user-guide/module-discovery/show-device.md
+++ b/ipmctl-user-guide/module-discovery/show-device.md
@@ -17,7 +17,7 @@ ipmctl show [OPTIONS] -dimm [TARGETS]
 List a few key fields for each persistent memory module.
 
 ```text
-$ ipmctl show -dimm
+$ sudo ipmctl show -dimm
 
  DimmID | Capacity  | HealthState | ActionRequired | LockState | FWVersion
 ==============================================================================
@@ -38,13 +38,13 @@ $ ipmctl show -dimm
 List all properties for module 0x0001.
 
 ```text
-$ ipmctl show -a -dimm 0x0001
+$ sudo ipmctl show -a -dimm 0x0001
 ```
 
 Retrieve specific properties for each module.
 
 ```text
-$ ipmctl show -d HealthState,LockState -dimm 0x0001
+$ sudo ipmctl show -d HealthState,LockState -dimm 0x0001
 
 ---DimmID=0x0001---
    LockState=Disabled

--- a/ipmctl-user-guide/module-discovery/show-memory-resources.md
+++ b/ipmctl-user-guide/module-discovery/show-memory-resources.md
@@ -11,7 +11,7 @@ ipmctl show [OPTIONS] -memoryresources
 Show persistent memory module resource allocation.
 
 ```text
-$ ipmctl show -memoryresources
+$ sudo ipmctl show -memoryresources
 
 Capacity=1517.0 GiB
 MemoryCapacity=0.0 GiB

--- a/ipmctl-user-guide/module-discovery/show-socket.md
+++ b/ipmctl-user-guide/module-discovery/show-socket.md
@@ -15,7 +15,7 @@ ipmctl show [OPTIONS] -socket [TARGETS]
 Display information about all the processors.
 
 ```text
-$ ipmctl show -socket
+$ sudo ipmctl show -socket
 
  SocketID | MappedMemoryLimit | TotalMappedMemory
 ==================================================
@@ -36,7 +36,7 @@ List all properties for socket 1.
 Retrieve specific properties for each processor.
 
 ```text
-$ ipmctl show -d MappedMemoryLimit -socket
+$ sudo ipmctl show -d MappedMemoryLimit -socket
 
 ---SocketID=0x0000---
    MappedMemoryLimit=4608.0 GiB

--- a/ipmctl-user-guide/module-discovery/show-system-capabilities.md
+++ b/ipmctl-user-guide/module-discovery/show-system-capabilities.md
@@ -9,7 +9,7 @@ ipmctl show [OPTIONS] -system -capabilities
 ### **Example**
 
 ```text
-$ ipmctl show -system -capabilities
+$ sudo ipmctl show -system -capabilities
 
 PlatformConfigSupported=1
 Alignment=1.0 GiB

--- a/ipmctl-user-guide/module-discovery/show-topology.md
+++ b/ipmctl-user-guide/module-discovery/show-topology.md
@@ -15,7 +15,7 @@ ipmctl show [OPTIONS] -topology [TARGETS]
 ### **Example**
 
 ```text
-$ ipmctl show -topology
+$ sudo ipmctl show -topology
 
  DimmID | MemoryType                  | Capacity  | PhysicalID| DeviceLocator
 ==============================================================================

--- a/ipmctl-user-guide/provisioning/delete-memory-allocation-goal.md
+++ b/ipmctl-user-guide/provisioning/delete-memory-allocation-goal.md
@@ -3,7 +3,7 @@
 Deletes the memory allocation goal from one or more persistent memory modules. This command deletes a memory allocation goal request that has not yet been processed by the BIOS.
 
 ```text
-$ ipmctl delete [OPTIONS] -goal [TARGETS]
+ipmctl delete [OPTIONS] -goal [TARGETS]
 ```
 
 ### **Targets**
@@ -14,6 +14,6 @@ $ ipmctl delete [OPTIONS] -goal [TARGETS]
 ### **Example**
 
 ```text
-$ ipmctl delete -goal
+$ sudo ipmctl delete -goal
 ```
 

--- a/ipmctl-user-guide/provisioning/dump-memory-allocation-settings.md
+++ b/ipmctl-user-guide/provisioning/dump-memory-allocation-settings.md
@@ -3,13 +3,13 @@
 Store the currently configured memory allocation settings for all persistent memory modules in the system to a file in order to replicate the configuration elsewhere. Apply the stored memory allocation settings using the command [Load Memory Allocation Goal](load-memory-allocation-goal.md)
 
 ```text
-$ ipmctl dump [OPTIONS] -destination (path) -system -config
+ipmctl dump [OPTIONS] -destination (path) -system -config
 ```
 
 ### **Example**
 
 ```text
-$ ipmctl dump -destination config.txt -system -config
+$ sudo ipmctl dump -destination config.txt -system -config
 ```
 
 ### **Limitations** 

--- a/ipmctl-user-guide/provisioning/load-memory-allocation-goal.md
+++ b/ipmctl-user-guide/provisioning/load-memory-allocation-goal.md
@@ -7,7 +7,7 @@ Load a memory allocation goal from a file onto one or more persistent memory mod
 > > Changing a memory allocation goal modifies how the platform firmware maps persistent memory in the system address space \(SPA\), which may result in data loss or inaccessible data, but does not explicitly delete or modify user data found in persistent memory.
 
 ```text
-$ ipmctl load [OPTIONS] -source (path) -goal [TARGETS]
+ipmctl load [OPTIONS] -source (path) -goal [TARGETS]
 ```
 
 ### **Targets**
@@ -20,19 +20,19 @@ $ ipmctl load [OPTIONS] -source (path) -goal [TARGETS]
 Load the configuration settings stored in "config.txt" onto all modules in the system as a memory allocation goal to be applied by the BIOS on the next reboot.
 
 ```text
-$ ipmctl load -source config.txt -goal
+$ sudo ipmctl load -source config.txt -goal
 ```
 
 Load the configuration settings stored in "config.txt" onto modules 1, 2, and 3 in the system as a memory allocation goal to be applied by the BIOS on the next reboot.
 
 ```text
-$ ipmctl load -source config.txt -goal -dimm 1,2,3
+$ sudo ipmctl load -source config.txt -goal -dimm 1,2,3
 ```
 
 Load the configuration settings stored in "config.txt" onto all manageable modules on sockets 1 and 2 as a memory allocation goal to be applied by the BIOS on the next reboot.
 
 ```text
-$ ipmctl load -source config.txt -goal -socket 1,2
+$ sudo ipmctl load -source config.txt -goal -socket 1,2
 ```
 
 ### **Limitations**

--- a/ipmctl-user-guide/provisioning/provision-app-direct.md
+++ b/ipmctl-user-guide/provisioning/provision-app-direct.md
@@ -5,10 +5,10 @@ Creates a memory allocation goal for App Direct in either one fully interleaved 
 **Examples**
 
 ```text
-$ ipmctl create -goal PersistentMemoryType=AppDirect
+$ sudo ipmctl create -goal PersistentMemoryType=AppDirect
 ```
 
 ```text
-$ ipmctl create -goal PersistentMemoryType=AppDirectNotInterleaved
+$ sudo ipmctl create -goal PersistentMemoryType=AppDirectNotInterleaved
 ```
 

--- a/ipmctl-user-guide/provisioning/provision-memory-mode.md
+++ b/ipmctl-user-guide/provisioning/provision-memory-mode.md
@@ -7,7 +7,7 @@ Creates a memory allocation goal for a percentage \(0-100\) of total capacity to
 Configure 100% of the available capacity on each persistent memory module to be in Memory Mode.
 
 ```text
-$ ipmctl create -goal MemoryMode=100
+$ sudo ipmctl create -goal MemoryMode=100
 ```
 
 By default, if a goal is set for any percentage less than 100%, the remaining capacity will be configured to App Direct mode. See the [Mixed Mode](provision-mixed-mode.md) section for examples. 

--- a/ipmctl-user-guide/provisioning/provision-mixed-mode.md
+++ b/ipmctl-user-guide/provisioning/provision-mixed-mode.md
@@ -7,12 +7,12 @@ Creates a memory allocation goal for a percentage \(0-100\) of total capacity to
 Configure 20% of the available capacity on each persistent memory module to be in Memory Mode and the remaining will be not-interleaved App Direct.
 
 ```text
-$ ipmctl create -goal MemoryMode=20 PersistentMemoryType=AppDirectNotInterleaved
+$ sudo ipmctl create -goal MemoryMode=20 PersistentMemoryType=AppDirectNotInterleaved
 ```
 
 Configure the persistent memory modules with 25% of the capacity in Memory Mode, 25% reserved, and the remaining 50% as interleaved App Direct by default.
 
 ```text
-$ ipmctl create -goal MemoryMode=25 Reserved=25
+$ sudo ipmctl create -goal MemoryMode=25 Reserved=25
 ```
 

--- a/ipmctl-user-guide/provisioning/show-memory-allocation-goal.md
+++ b/ipmctl-user-guide/provisioning/show-memory-allocation-goal.md
@@ -14,11 +14,11 @@ ipmctl show [OPTIONS] -goal [TARGETS] [PROPERTIES]
 **Examples**
 
 ```text
-$ ipmctl show -goal
+$ sudo ipmctl show -goal
 ```
 
 ```text
-$ ipmctl show -goal -socket 1
+$ sudo ipmctl show -goal -socket 1
 ```
 
 **Return Data**

--- a/ipmctl-user-guide/security/change-device-passphrase.md
+++ b/ipmctl-user-guide/security/change-device-passphrase.md
@@ -21,19 +21,19 @@ ipmctl set [OPTIONS] -dimm [TARGETS] Passphrase=(string) NewPassphrase=(string) 
 Change the passphrase from `mypassphrase` to `mynewpassphrase` on all modules.
 
 ```text
-$ ipmctl set -dimm Passphrase=mypassphrase NewPassphrase=mynewpassphrase ConfirmPassphrase=mynewpassphrase
+$ sudo ipmctl set -dimm Passphrase=mypassphrase NewPassphrase=mynewpassphrase ConfirmPassphrase=mynewpassphrase
 ```
 
 Change the passphrase on all modules by having the CLI prompt for the current and new passphrases.
 
 ```text
-$ ipmctl set -dimm Passphrase="" NewPassphrase="" ConfirmPassphrase=""
+$ sudo ipmctl set -dimm Passphrase="" NewPassphrase="" ConfirmPassphrase=""
 ```
 
 Change the passphrase on all modules by supplying the current and new passphrases from the specified file.
 
 ```text
-$ ipmctl set -source passphrase.file -dimm Passphrase="" NewPassphrase="" ConfirmPassphrase=""
+$ sudo ipmctl set -source passphrase.file -dimm Passphrase="" NewPassphrase="" ConfirmPassphrase=""
 ```
 
 In the previous example, the format of the file would be:

--- a/ipmctl-user-guide/security/change-device-security.md
+++ b/ipmctl-user-guide/security/change-device-security.md
@@ -3,7 +3,7 @@
 Changes the data-at-rest security lock state for the persistent memory on one or more persistent memory modules.
 
 ```text
-$ ipmctl set [OPTIONS] -dimm [TARGETS] Lockstate=(Unlocked|Disabled|Frozen) Passphrase=(string)
+ipmctl set [OPTIONS] -dimm [TARGETS] Lockstate=(Unlocked|Disabled|Frozen) Passphrase=(string)
 ```
 
 ### **Targets**
@@ -23,7 +23,7 @@ $ ipmctl set [OPTIONS] -dimm [TARGETS] Lockstate=(Unlocked|Disabled|Frozen) Pass
 Unlock device 0x0001
 
 ```text
-$ ipmctl set -dimm 0x0001 LockState=Unlocked Passphrase=""
+$ sudo ipmctl set -dimm 0x0001 LockState=Unlocked Passphrase=""
 ```
 
 Unlock device 0x0001 by supplying the passphrase in the file "mypassphrase.file".

--- a/ipmctl-user-guide/security/enable-device-security.md
+++ b/ipmctl-user-guide/security/enable-device-security.md
@@ -3,7 +3,7 @@
 Enable data-at-rest security for the persistent memory on one or more persistent memory modules by setting a passphrase. For better passphrase protection, specify an empty string \(e.g., ConfirmPassphrase=""\) to be prompted for the passphrase or to use a file containing the passphrase with the source option.
 
 ```text
-$ ipmctl set [OPTIONS] -dimm [TARGETS] NewPassphrase=(string) ConfirmPassphrase=(string)
+ipmctl set [OPTIONS] -dimm [TARGETS] NewPassphrase=(string) ConfirmPassphrase=(string)
 ```
 
 ### **Targets**
@@ -22,7 +22,7 @@ $ ipmctl set [OPTIONS] -dimm [TARGETS] NewPassphrase=(string) ConfirmPassphrase=
 Set a passphrase on DIMM 0x0001
 
 ```text
-$ ipmctl set -dimm 0x0001 NewPassphrase=123 ConfirmPassphrase=123
+$ sudo ipmctl set -dimm 0x0001 NewPassphrase=123 ConfirmPassphrase=123
 ```
 
 Set a passphrase on DIMM 0x0001 by supplying the passphrase in the file mypassphrase.file.

--- a/ipmctl-user-guide/security/erase-device-data.md
+++ b/ipmctl-user-guide/security/erase-device-data.md
@@ -3,7 +3,7 @@
 Erases the persistent data on one or more module.
 
 ```text
-$ ipmctl delete [OPTIONS] -dimm [TARGETS] Passphrase=(string)
+ipmctl delete [OPTIONS] -dimm [TARGETS] Passphrase=(string)
 ```
 
 ### **Targets**
@@ -19,19 +19,19 @@ $ ipmctl delete [OPTIONS] -dimm [TARGETS] Passphrase=(string)
 Security disabled modules: Erase all persistent data on all modules in the system
 
 ```text
-$ ipmctl delete -dimm
+$ sudo ipmctl delete -dimm
 ```
 
 Security enabled specifics: Erase all the persistent data on all modules in the system
 
 ```text
-$ ipmctl delete -dimm Passphrase=123
+$ sudo ipmctl delete -dimm Passphrase=123
 ```
 
 Erase all the persistent data on all modules using the CLI prompt for the current passphrase.
 
 ```text
-$ ipmctl delete -dimm Passphrase=""
+$ sudo ipmctl delete -dimm Passphrase=""
 ```
 
 ### **Limitations**

--- a/ipmctl-user-guide/support-and-maintenance/show-events.md
+++ b/ipmctl-user-guide/support-and-maintenance/show-events.md
@@ -3,7 +3,7 @@
 Shows persistent memory module related events. The options, targets, and properties can be used to filter the events. If no filters are provided, the default is to display up to 50 events. Refer to the Event Log Specification for detailed information about events.
 
 ```text
-$ ipmctl show [OPTIONS] -event [TARGETS] [PROPERTIES]
+ipmctl show [OPTIONS] -event [TARGETS] [PROPERTIES]
 ```
 
 ### **Targets**
@@ -35,13 +35,13 @@ $ ipmctl show [OPTIONS] -event [TARGETS] [PROPERTIES]
 Display the 50 most recent events.
 
 ```text
-$ ipmctl show -event
+$ sudo ipmctl show -event
 ```
 
 Show the 10 most recent error events. With the exception that this call limits the output to 10, this is equivalent to calling `ipmctl show -error`.
 
 ```text
-$ ipmctl show -event count=10 severity=error
+$ sudo ipmctl show -event count=10 severity=error
 ```
 
 ### **Return Data** 

--- a/ipmctl-user-guide/support-and-maintenance/version-and-firmware.md
+++ b/ipmctl-user-guide/support-and-maintenance/version-and-firmware.md
@@ -5,7 +5,7 @@
 Shows the persistent memory module host software versions
 
 ```text
-$ ipmctl version
+$ sudo ipmctl version
 ```
 
 ### Show Device Firmware
@@ -13,7 +13,7 @@ $ ipmctl version
 Shows detailed information about the firmware on one or more modules
 
 ```text
-$ ipmctl show [OPTIONS] -firmware [TARGETS]
+ipmctl show [OPTIONS] -firmware [TARGETS]
 ```
 
 ### Update Firmware 
@@ -21,7 +21,7 @@ $ ipmctl show [OPTIONS] -firmware [TARGETS]
 Updates the firmware on one or more modules
 
 ```text
-$ ipmctl load [OPTIONS] -source (path) -dimm (DimmIds) [TARGETS]
+ipmctl load [OPTIONS] -source (path) -dimm (DimmIds) [TARGETS]
 ```
 
 > NOTE: If Address Range Scrub \(ARS\) is in progress on any target DIMM, an attempt will be made to abort ARS and the proceed with the firmware update.
@@ -33,13 +33,13 @@ $ ipmctl load [OPTIONS] -source (path) -dimm (DimmIds) [TARGETS]
 Update the firmware on all modules in the system to the image in sourcefile.pkg on the next power cycle.
 
 ```text
-$ ipmctl load -source sourcefile.pkg -dimm
+$ sudo ipmctl load -source sourcefile.pkg -dimm
 ```
 
 Check the firmware image in sourcefile.pkg and retrieve the version.
 
 ```text
-$ ipmctl load -examine -source sourcefile.pkg -dimm
+$ sudo ipmctl load -examine -source sourcefile.pkg -dimm
 ```
 
 > NOTE: Once a firmware image is staged for execution, a power cycle is required before another firmware image of the same type \(production or debug\) can be staged for execution using this command.


### PR DESCRIPTION
ipmctl requires root privileges to run correctly.
`sudo` is added after `$` to all examples to avoid user confusion when using copy-paste.

